### PR TITLE
Expose GLView in Sketch and ImageFilter components.

### DIFF
--- a/lib/components/FilterImage.js
+++ b/lib/components/FilterImage.js
@@ -146,6 +146,8 @@ export default class FilterImage extends React.Component<Props> {
     this.props.onReady && this.props.onReady(context);
   };
 
+  _viewRef = ref => { this.glView = ref; }
+
   render() {
     return (
       <Expo.GLView
@@ -153,6 +155,7 @@ export default class FilterImage extends React.Component<Props> {
         key={'Expo.FilterImage-' + global.__ExpoSketchId}
         {...this.props}
         onContextCreate={this.onContextCreate}
+        ref={ this._viewRef }
       />
     );
   }

--- a/lib/components/Sketch.js
+++ b/lib/components/Sketch.js
@@ -213,6 +213,8 @@ export default class Sketch extends React.Component<Props> {
     }
   };
 
+  _viewRef = ref => { this.glView = ref; }
+
   render() {
     return (
       <Expo.GLView
@@ -221,6 +223,7 @@ export default class Sketch extends React.Component<Props> {
         key={'Expo.Sketch-' + global.__ExpoSketchId}
         {...this.props}
         onContextCreate={this.onContextCreate}
+        ref={ this._viewRef }
       />
     );
   }


### PR DESCRIPTION
This PR exposes a `ref` to the underlying `<Expo.GLView>` of of the `<Sketch>` and `<FilterImage>` components.  This enhancement will allow users to take advantage of Expo SDK 26.0.0's new `Expo.GLView.takeSnapshotAsync()` method.  With this new method, Android users can create a JPEG image of their sketch doodles.

The common way of taking a snap shot using `Expo.takeSnapshotAsync()` does not work on Android (see [Expo Issue 1371](https://github.com/expo/expo/issues/1371)).