### PR TITLE
Adds a clear method on the Sketch component

### DIFF
--- a/lib/components/Sketch.js
+++ b/lib/components/Sketch.js
@@ -161,6 +161,20 @@ export default class Sketch extends React.Component<Props> {
     }
   };
 
+  clear = () => {
+    this.provider.reset();
+    if (!this.renderer) {
+      return null;
+    }
+
+    if (this.stage.children.length > 0) {
+      this.stage.removeChildren();
+      this.renderer._update();
+    }
+
+    return null;
+  };
+
   takeSnapshotAsync = (...args) => {
     return takeSnapshotAsync(this.glView, ...args);
   };


### PR DESCRIPTION
The Sketch component has an undo method but doesn't have a clear method.

 I had to look for a while to be able to clear my sketches and ended up finding this method on the Signature component. 

I think this could be useful for other people 👍