### PR TITLE
Pixi.js has a vulnerability on 4.7.0 > ismobilejs, upgrading to 4.8.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "path": "^0.12.7",
     "pixi-filters": "*",
     "pixi-spine": "^1.5.11",
-    "pixi.js": "^4.7.0",
+    "pixi.js": "^4.8.4",
     "url": "^0.11.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7373,7 +7373,7 @@ pixi-spine@^1.5.11:
   dependencies:
     "@types/pixi.js" "^4.8.0"
 
-pixi.js@^4.7.0:
+pixi.js@^4.8.4:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/pixi.js/-/pixi.js-4.8.5.tgz#33eef7d1440f38b0057908121c28f93ea7c5b405"
   integrity sha512-eYGvuzIOAOepoFDHu3GmvRqM2tJ/IBwHnfxB6BxGxDOQOaNfWMT9LA5IlUY9K3YEnEd3YtD0Nsx5aRxCyzYQeQ==


### PR DESCRIPTION
https://app.snyk.io/vuln/SNYK-JS-ISMOBILEJS-72624

Can we please move pixi.js forward on this project to remove the High priority warning on Snyk from projects using expo-pixi?

This is a duplicate of https://github.com/expo/expo-pixi/pull/47 which I accidentally closed.