### PR TITLE
Find a combination of packages that works reliably

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,13 +54,14 @@
     ]
   },
   "dependencies": {
-    "@expo/browser-polyfill": "^0.0.1-alpha.4",
+    "@expo/browser-polyfill": "0.0.1-alpha.3",
+    "expo-asset-utils": "1.1.0",
     "fbemitter": "2.1.1",
+    "gl-matrix": "^3.0.0",
     "path": "^0.12.7",
     "pixi-filters": "*",
     "pixi-spine": "^1.5.11",
     "pixi.js": "^4.7.0",
-    "expo-asset-utils": "^1.1.0",
     "url": "^0.11.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
As per issue #77 here is a combination of packages that seem to work reliably using `yarn` (tested by removing `node_modules` and `yarn.lock` and then reinstalling everything. I tried `"@expo/browser-polyfill": "0.0.1-alpha.4"` but that didn't work so left it at `alpha.3`.