### PR TITLE
Remove this.provider from Sketch

### DIFF
--- a/lib/components/Sketch.js
+++ b/lib/components/Sketch.js
@@ -162,7 +162,6 @@ export default class Sketch extends React.Component<Props> {
   };
 
   clear = () => {
-    this.provider.reset();
     if (!this.renderer) {
       return null;
     }


### PR DESCRIPTION
Clear was crashing because `this.provider` does not exist

Would close #80 