### PR TITLE
Updated @expo/browser-polyfill to use latest version ^0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     ]
   },
   "dependencies": {
-    "@expo/browser-polyfill": "^0.0.1-alpha.4",
+    "@expo/browser-polyfill": "^0.1.0",
     "fbemitter": "2.1.1",
     "path": "^0.12.7",
     "pixi-filters": "*",


### PR DESCRIPTION
@expo/browser-polyfill ^0.0.1-alpha.4 is using deprecated methods

import { FileSystem } from 'expo' -> import * as FileSystem from 'expo-file-system'