### PR TITLE
fixed pixi-filters incompatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@expo/browser-polyfill": "^0.1.0",
     "fbemitter": "2.1.1",
     "path": "^0.12.7",
-    "pixi-filters": "*",
+    "pixi-filters": "2.7.1",
     "pixi-spine": "^1.5.11",
     "pixi.js": "^4.7.0",
     "expo-asset-utils": "^1.1.0",


### PR DESCRIPTION
set the pixi-filters dependency version number to 2.7.1, the last
version compatible with pixi 4.7. The wildcard version
caused pixi v5.2 to be imported as a dependency. The filters designed
for version pixi 5.2 are incompatible with pixi 4.7, the version used by
expo-pixi.