### PR TITLE
Preventing componentWillMount renaming warning

### DIFF
--- a/examples/comprehensive/components/TouchableView.js
+++ b/examples/comprehensive/components/TouchableView.js
@@ -47,7 +47,7 @@ class TouchableView extends React.Component {
       },
     });
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this._panResponder = this.buildGestures();
   }
 

--- a/examples/filter-image/App.js
+++ b/examples/filter-image/App.js
@@ -56,7 +56,7 @@ export default class App extends Component {
     index: 0,
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     console.log('pixi filters', PIXI.filters);
 
     const filter = filters => {

--- a/lib/components/FilterImage.js
+++ b/lib/components/FilterImage.js
@@ -38,7 +38,7 @@ type Props = {
 };
 
 export default class FilterImage extends React.Component<Props> {
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     global.__ExpoFilterImageId++;
   }
 

--- a/lib/components/Signature.js
+++ b/lib/components/Signature.js
@@ -41,7 +41,7 @@ export default class Signature extends React.Component<Props> {
     this._setupPanResponder();
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     global.__ExpoSignatureId++;
   }
 

--- a/lib/components/Sketch.js
+++ b/lib/components/Sketch.js
@@ -43,7 +43,7 @@ export default class Sketch extends React.Component<Props> {
   panResponder: PanResponder;
   renderer: PIXI.Renderer;
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     global.__ExpoSketchId++;
     this.setupPanResponder();
   }


### PR DESCRIPTION
Added UNSAFE_ prefix to componentWillMount as quick fix to remove constant warnings and so expo-pixi will continue to work in React 17.x