### PR TITLE
Updated README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,8 +171,6 @@ const App = (props) => {
 export default App;
 ```
 
-
-
 #### Capturing image of sketch using React.useRef [(Snack)](https://snack.expo.io/@unexpectederr/expo-pixi-snapshot-with-react.useref)
 
 ```react
@@ -209,13 +207,5 @@ const App = (props) => {
 export default App;
 
 ```
-
-
-
-
-
-
-
-
 
 [![NPM](https://nodei.co/npm/expo-pixi.png)](https://nodei.co/npm/expo-pixi/)

--- a/README.md
+++ b/README.md
@@ -148,25 +148,74 @@ A Image component that uses PIXI.Filter
 
 ## Example
 
-**[Snack](https://snack.expo.io/@bacon/base-pixi.js)**
+### ExpoPixi.Sketch
 
-```js
+#### Basic usage [(Snack)](https://snack.expo.io/@unexpectederr/expo-pixi-with-react-hooks)
+
+```react
 import React from 'react';
-import Expo from 'expo';
-import { PIXI } from 'expo-pixi';
+import ExpoPixi from 'expo-pixi';
 
-export default () => (
-  <Expo.GLView
-    style={{ flex: 1 }}
-    onContextCreate={async context => {
-      const app = new PIXI.Application({ context });
-      const sprite = await PIXI.Sprite.fromExpoAsync(
-        'http://i.imgur.com/uwrbErh.png',
-      );
-      app.stage.addChild(sprite);
-    }}
-  />
-);
+const App = (props) => {
+  return(
+      <ExpoPixi.Sketch
+      onChange={() => console.log("Lines changed")}
+      onReady={() => console.log("Canvas ready")}
+      strokeColor="0x555555"
+      strokeWidth={15}
+      strokeAlpha={1} 
+      style={{height: "100%", width: "100%", backgroundColor: "black"}} />
+  )
+}
+
+export default App;
 ```
+
+
+
+#### Capturing image of sketch using React.useRef [(Snack)](https://snack.expo.io/@unexpectederr/expo-pixi-snapshot-with-react.useref)
+
+```react
+import React, { useRef } from 'react';
+import {Button} from "react-native";
+import ExpoPixi from 'expo-pixi';
+
+const App = (props) => {
+  const sketchRef = useRef(null)
+
+  function takeSnapshot() {
+    // Call the takeSnapshotAsync function on the ref attached to the ExpoPixi.Sketch component
+    sketchRef.current.takeSnapshotAsync({format: "png"}).then((data) => {
+      // Do something with the data (update state, save to memory, etc)
+      console.log(data)
+    })
+  }
+
+  return(
+    <>
+      <ExpoPixi.Sketch
+      onChange={() => console.log("Lines changed")}
+      onReady={() => console.log("Canvas ready")}
+      ref={sketchRef}
+      strokeColor="0x555555"
+      strokeWidth={15}
+      strokeAlpha={1} 
+      style={{height: "90%", width: "100%", backgroundColor: "black"}} />
+      <Button title="Take Snapshot" onPress={() => takeSnapshot()}/>
+    </>
+  )
+}
+
+export default App;
+
+```
+
+
+
+
+
+
+
+
 
 [![NPM](https://nodei.co/npm/expo-pixi.png)](https://nodei.co/npm/expo-pixi/)


### PR DESCRIPTION
Have been using ExpoPixi in an application of mine, but found the examples to be confusing and used older class components. I am only using ExpoPixi.Sketch, so I just added some simple examples to help out others to use the sketch component. They also demonstrate how to use the new features of React such as functional components and hooks (such as useRef)

Changes:
- Added two examples with accompanying snacks
- Removed the broken example