### PR TITLE
Fixes to make ExpoPixi.Signature work on web

### DIFF
--- a/lib/components/Signature.js
+++ b/lib/components/Signature.js
@@ -41,7 +41,7 @@ export default class Signature extends React.Component<Props> {
     this._setupPanResponder();
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     global.__ExpoSignatureId++;
   }
 

--- a/lib/components/Signature.js
+++ b/lib/components/Signature.js
@@ -127,8 +127,10 @@ export default class Signature extends React.Component<Props> {
     return null;
   };
 
-  takeSnapshotAsync = (...args) => {
-    return takeSnapshotAsync(this.glView, ...args);
+  takeSnapshotAsync = async (...args) => {
+    if (Platform.OS === "web") 
+      return await GLView.takeSnapshotAsync(this.context, ...args);
+    return await takeSnapshotAsync(this.glView, ...args);
   };
 
   onContextCreate = async (context: WebGLRenderingContext) => {

--- a/lib/components/Signature.js
+++ b/lib/components/Signature.js
@@ -1,7 +1,7 @@
 //@flow
 import React from 'react';
 import { GLView } from 'expo-gl';
-import { PanResponder, PixelRatio } from 'react-native';
+import { Platform, PanResponder, PixelRatio } from 'react-native';
 import { vec2 } from 'gl-matrix';
 
 import PIXI from '../Pixi';
@@ -138,7 +138,10 @@ export default class Signature extends React.Component<Props> {
     this.stage = new PIXI.Container();
     this.stage.addChild(this.graphicsTmp);
 
-    const getAttributes = context.getContextAttributes || (() => ({}));
+    const getAttributes = (Platform.OS === 'web') ?
+      (() => ({})) :
+      context.getContextAttributes || (() => ({}));
+
     context.getContextAttributes = () => {
       const contextAttributes = getAttributes();
       return {

--- a/lib/components/Signature.js
+++ b/lib/components/Signature.js
@@ -185,15 +185,28 @@ export default class Signature extends React.Component<Props> {
   };
 
   render() {
+    if (Platform.OS === 'web') {
+      const glView = (
+        <GLView
+          {...this.panResponder.panHandlers}
+          onLayout={this.onLayout}
+          key={'Expo.Signature-' + global.__ExpoSignatureId}
+          {...this.props}
+          onContextCreate={this.onContextCreate}
+        />
+      );
+      this.setRef(glView);
+      return glView;
+    }
     return (
-      <GLView
-        {...this.panResponder.panHandlers}
-        onLayout={this.onLayout}
-        key={'Expo.Signature-' + global.__ExpoSignatureId}
-        ref={this.setRef}
-        {...this.props}
-        onContextCreate={this.onContextCreate}
-      />
-    );
+        <GLView
+          {...this.panResponder.panHandlers}
+          onLayout={this.onLayout}
+          ref={this.setRef}
+          key={'Expo.Signature-' + global.__ExpoSignatureId}
+          {...this.props}
+          onContextCreate={this.onContextCreate}
+        />
+    )
   }
 }


### PR DESCRIPTION
1. disables the `getContextAttributes` from context on web platform cf #147 
2. changes the `ref` assignment for GLView. There's an issue opened on expo-gl, because I believe it should be fixed there, not here. cf expo/expo#10774.
3. Fixes the `takeSnapshotAsync()` call for the web platform by using the static call. I'm not sure why the local utils one is actually failing to call the bound one.

About 3. I did not make an issue, because even though the `takeSnapshotAsync` call works, it only saves blank images. I need to figure out why (maybe I'm giving it a wrong context? 🤔 )

This could be three distinct one commit PR, though I believe they all belong together as it's achieving one goal: make Signature work on the web :)