### PR TITLE
Fixes expo-pixi for expo 43

### DIFF
--- a/lib/spineAsync.js
+++ b/lib/spineAsync.js
@@ -1,4 +1,4 @@
-import { uriAsync } from 'expo-asset-utils';
+import { resolveAsync } from 'expo-asset-utils';
 import { readAsStringAsync } from 'expo-file-system';
 import PIXI from './Pixi';
 
@@ -16,6 +16,15 @@ async function jsonFromResourceAsync(resource) {
   const jsonUrl = await uriAsync(resource);
   const jsonString = await readAsStringAsync(jsonUrl);
   return JSON.parse(jsonString);
+}
+
+// https://github.com/expo/expo-asset-utils/blob/1.1.1/src/uriAsync.js
+async function uriAsync(fileReference) {
+  const asset = await resolveAsync(fileReference);
+  if (!asset) {
+    throw new Error(`expo-pixi: uriAsync(): failed to resolve asset: ${fileReference}`);
+  }
+  return asset.localUri;
 }
 
 async function spineAsync({ json, atlas, assetProvider }) {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "pixi-filters": "*",
     "pixi-spine": "^1.5.11",
     "pixi.js": "^4.7.0",
-    "expo-asset-utils": "^1.1.0",
+    "expo-asset-utils": "^3.0.0",
     "url": "^0.11.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-pixi",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "sideEffects": true,
   "description": "Tools for using pixi in Expo",
   "license": "MIT",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4406,10 +4406,10 @@ expo-2d-context@^0.0.2:
     string-format "0.5.0"
     tess2 "^1.0.0"
 
-expo-asset-utils@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/expo-asset-utils/-/expo-asset-utils-1.2.0.tgz#df52f8e8c836c343ad713a0044db79be69cfe64b"
-  integrity sha512-06zVi5aXzyMq7SFiawxu2FUbpbVlxnE9W44cG4K5HyhLaqyRqss+o5MZMEGn8Ibd+008UiK7yCPy/bSpx2hVag==
+expo-asset-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/expo-asset-utils/-/expo-asset-utils-3.0.0.tgz#2c7ddf71ba9efacf7b46c159c1c650114a2f14dc"
+  integrity sha512-CgIbNvTqKqQi1lrlptmwoaCMu4ZVOZf8tghmytlor23CjIOuorw6cfuOqiqWkJLz23arTt91maYEU9XLMPB23A==
 
 express-session@~1.11.3:
   version "1.11.3"


### PR DESCRIPTION
This repo was using expo-asset-utils 1.2.0 and this version doesn't work anymore on expo 43. Expo-asset-utils has a deprecation notice pointing to expo-assets and expo-file-system but I wasn't sure which methods from these modules should be used to replace resolveAsync 

Cheers, 