### PR TITLE
fix peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "url": "^0.11.0"
   },
   "peerDependencies": {
-    "expo-gl": "~4.0.0"
+    "expo-gl": "*"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",


### PR DESCRIPTION
expo-pixi can't be used with package managers that enforce peer dependecies